### PR TITLE
Fix utest target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ push:
 #	gcloud docker -- push ${REGISTRY}/fc-retrieval-client:${VERSION}
 
 utest:
-	sudo go test ./...
+	go test ./...
 
 # remove previous images and containers
 clean:

--- a/pkg/client/network.go
+++ b/pkg/client/network.go
@@ -35,6 +35,7 @@ func Ping(pingserver string) bool {
 	}
 
 	p := fastping.NewPinger()
+	p.Network("udp")
 	ra, err := net.ResolveIPAddr("ip4:icmp", pingserver)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
Now using UDP for ICMP to avoid need for superuser privileges.